### PR TITLE
Fix missing permission

### DIFF
--- a/.github/workflows/homeassistant-deploy.yml
+++ b/.github/workflows/homeassistant-deploy.yml
@@ -13,6 +13,8 @@ jobs:
         runs-on: ubuntu-latest
         environment: Home
         name: Deploy Home Assistant
+        permissions:
+          id-token: write
         steps:
             - name: Check out from GitHub
               uses: actions/checkout@v3


### PR DESCRIPTION
## What changed?

Give deploy job missing permission to access AWS token, per [GitHub Documentation](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)

## How has it been tested?

The only way I know to test is in production 😢 