### PR TITLE
Add school delays

### DIFF
--- a/homeassistant/packages/weather.yaml
+++ b/homeassistant/packages/weather.yaml
@@ -1,0 +1,36 @@
+# Various stuff relating to weather
+
+input_text:
+  delay_school_district:
+    name: Delay School District
+    icon: mdi:weather-snowy
+
+# Pull in closing and delays from local news site
+rest:
+  - scan_interval: 300
+    resource: !secret local_url_news_1_wp_variables
+    
+    sensor:
+      - name: School Delay Status
+        unique_id: school_delay_status
+        value_template: |-
+          {% set closings = value_json.alert_banners.messages.Closings -%}
+          {% set matched = closings | selectattr('content', 'eq', states('input_text.delay_school_district')) | list -%}
+          {% if matched | count > 0 -%}
+            {{ (matched | first).status }}
+          {%- else -%}
+            None
+          {%- endif -%}
+    binary_sensor:
+      - name: School Delay
+        unique_id: school_delay
+        device_class: safety
+        value_template: |-
+          {% set closings = value_json.alert_banners.messages.Closings -%}
+          {% set matched = closings | selectattr('content', 'eq', states('input_text.delay_school_district')) | list -%}
+          {% if matched | count > 0 -%}
+            1
+          {%- else -%}
+            0
+          {%- endif -%}
+        

--- a/homeassistant/secrets.yaml.tpl
+++ b/homeassistant/secrets.yaml.tpl
@@ -1,5 +1,9 @@
 recorder_db_url: op://${HASS_VAULT_ID}/recorder_db_url/password
 
+# Local secrets
+
+local_url_news_1_wp_variables: op://${HASS_VAULT_ID}/local/local_url_news_1_wp_variables
+
 # Webhooks
 
 webhook_ci_push: op://${HASS_VAULT_ID}/webhook_ci_push/id


### PR DESCRIPTION
## What changed?

Add school delays/closings to Home Assistant. 

This pulls information from a local news site, which internally exposes some of the banners and alerts on the site in JSON, allowing me to check if our local school district is there.

## How was it tested?

Ran on a local Home Assistant instance.