### PR TITLE
✨ Add modules, starting with Home Assistant Voice

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "modules/home-assistant-voice-pe"]
+	path = modules/home-assistant-voice-pe
+	url = https://github.com/pacorain/home-assistant-voice-pe

--- a/README.md
+++ b/README.md
@@ -2,12 +2,18 @@
 
 v3 of my Smart Home Config
 
+This is my third home automation config, built primarily on Home Assistant. This repo is like IaC for my home, and my goal is to push existing technologies and learn new ones.
+
 ---
 
 # Components
 
+This repo has several components:
+
+- [Core config](homeassistant/) - The main Home Assitant config
 - [Testing](#testing) - Unit tests and convention enforcement for config changes
 - [CI/CD](#cicd) - Automated testing and deployment
+- [Modules](modules/) - 
 
 ...more to come as I build out the config.
 

--- a/homeassistant/esphome/.gitignore
+++ b/homeassistant/esphome/.gitignore
@@ -1,0 +1,5 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml

--- a/homeassistant/esphome/home-assistant-voice-office.yaml
+++ b/homeassistant/esphome/home-assistant-voice-office.yaml
@@ -1,0 +1,21 @@
+substitutions:
+  name: home-assistant-voice-0995fb
+  friendly_name: Home Assistant Voice Office
+packages:
+  Nabu Casa.Home Assistant Voice PE: !include modules/home-assistant-voice-pe/home-assistant-voice.yaml
+external_components:
+  - source:
+      type: local
+      path: modules/home-assistant-voice-pe/esphome/components
+esphome:
+  name: ${name}
+  name_add_mac_suffix: false
+  friendly_name: ${friendly_name}
+api:
+  encryption:
+    key: !secret key_voice_office
+
+
+wifi:
+  ssid: !secret iot_wifi_ssid
+  password: !secret iot_wifi_password

--- a/homeassistant/esphome/secrets.yaml.tpl
+++ b/homeassistant/esphome/secrets.yaml.tpl
@@ -1,0 +1,8 @@
+# Encryption keys
+
+key_voice_office: {{ op://$HASS_VAULT_ID/key_voice_office/password }}
+
+# IOT WiFi
+
+iot_wifi_ssid: {{ op://$HASS_VAULT_ID/wifi_iot/ssid }}
+iot_wifi_password: {{ op://$HASS_VAULT_ID/wifi_iot/psk }}


### PR DESCRIPTION
This PR makes 3 changes to get customization to Home Assistant Voice.

# Modules

Add modules to toad. 

This allows me to bring in code from other repos, and make updates in my own time.

# ESPHome

Add my ESPHome config to Toad. 

## How has it been tested?

I still need to do the following: 

- [ ] Add testing to confirm the ESPHome config is valid (I don't plan on trying to set up similar unit testing to Home Assistant)
- [ ] Add CI to compile affected devices and push to Toad?

# Home Assistant Voice

Create a config for my Home Assistant Voice device I've just purchased.